### PR TITLE
Add `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: check-yaml
+    -   id: check-merge-conflict
+    -   id: check-json
+    -   id: requirements-txt-fixer
+-   repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        language_version: python3
+        args: ["--count", "--select=E9,F63,F7,F82", "--show-source", "--statistics"]
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.6.0
+    hooks:
+    -   id: autopep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy>=1.16.2
-torch>=1.8.0
 pillow>=6.1.0
 plyfile>=0.7.2
+pre-commit==2.17.0
+torch>=1.8.0
 tqdm>=4.40.2


### PR DESCRIPTION
This PR aims to solve #36. I've only added `flake8` and `autopep8` for now, with a couple of other miscellaneous hooks. `odak` follows a large set of configurations for `flake8` and it doesn't make sense IMO to add them as `args` in the pre-commit config. A `setup.cfg` or a `.flake8` configuration file makes more sense.

Looking forward to hear feedback.